### PR TITLE
Fix the deploy: untag the container app environment, serialize state access

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -6,6 +6,15 @@ on:
   pull_request:
     branches:
       - main
+
+# One Terraform state file means one run at a time. Merging a PR starts the pull_request
+# run and the push run within seconds of each other, both plan against the same remote
+# state, and the loser dies on a 409 "lease already present". Queue instead of cancelling:
+# a plan already in flight is doing useful work, and cancelling one mid-apply is worse.
+concurrency:
+  group: terraform-${{ github.repository }}
+  cancel-in-progress: false
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -51,12 +51,17 @@ resource "azurerm_log_analytics_workspace" "log_analytics" {
   tags = local.tags
 }
 
+# Deliberately untagged, unlike every other resource here. Any update to a container app
+# environment re-sends a full CreateOrUpdate, and its LogAnalyticsConfiguration has to
+# carry the workspace shared key - which the Azure API returns as null on every read. So
+# the provider faithfully sends that null back and Azure rejects the whole call with
+# "LogAnalyticsConfiguration is invalid". Adding four tags was enough to trigger it and
+# leave an apply half-finished. Four tags are not worth an unrunnable pipeline.
 resource "azurerm_container_app_environment" "env" {
   name                       = var.container_apps_environment_name
   location                   = var.location
   resource_group_name        = azurerm_resource_group.rg.name
   log_analytics_workspace_id = azurerm_log_analytics_workspace.log_analytics.id
-  tags                       = local.tags
 }
 
 # More secure: Disable ACR admin credentials


### PR DESCRIPTION
PR #3 merged correctly but its deploy failed twice, for two unrelated reasons. Neither was the AcrPull import, which worked — the plan came back `1 to import, 0 to add, 5 to change, 0 to destroy` and the import completed on the apply.

## 1. The container app environment cannot be tagged

```
400 InvalidRequestParameterWithDetails: LogAnalyticsConfiguration is invalid.
Must provide a valid LogAnalyticsConfiguration
```

Any update to a container app environment re-sends a full `CreateOrUpdate`, and its `LogAnalyticsConfiguration` has to carry the workspace shared key. Azure returns that key as `null` on every read:

```json
"logAnalyticsConfiguration": { "customerId": "cbb5739d-...", "sharedKey": null }
```

So the provider sends the null back and Azure rejects the whole call. Adding four tags was enough to trigger it. That resource is now deliberately untagged, with a comment explaining why.

The workspace and its link to the environment were never broken — log flow is intact and the new daily quota applied successfully.

## 2. Deploys race each other for the state lock

The first failure was earlier and unrelated:

```
409 There is already a lease present.  Operation: OperationTypePlan
```

Merging fires the `pull_request` run and the `push` run within seconds; both plan against the same remote state and the loser dies. A repository-wide concurrency group now queues them. Queue rather than cancel — cancelling a run mid-apply is worse than waiting.

## State right now

The failed apply was partial. Already applied: the AcrPull import, and tags plus the daily quota on the resource group, registry and workspace. Not applied: the environment tags (removed here) and the container app itself — so the probe move to `/health/live` and the weather secrets are still pending and will land with this.

The live service was unaffected throughout; `/health/live` answers 200 on the custom domain.

## After this merges

`/weather` runs against the real NWS API for the first time. Worth a look — a 503 there would mean the coordinate secrets did not reach the container, without taking anything else down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)